### PR TITLE
Issue: Order in model_list object is wrong.

### DIFF
--- a/R/generateData.R
+++ b/R/generateData.R
@@ -112,6 +112,7 @@ generateData <- function(
   ## Get the models
   model_list <- generatecSEMModel(.model, ...)
 
+
   ## Compute Sigma matrices
   sigma_list <- lapply(model_list$Models, generateSigma,
                        .handle_negative_definite = handle_negative_definite)

--- a/R/generateSigma.R
+++ b/R/generateSigma.R
@@ -188,6 +188,6 @@ generateSigma <- function(
            call. = FALSE)
     }
   } else {
-    list(Sigma, path_matrix)
+    Sigma
   }
 }

--- a/R/generateSigma.R
+++ b/R/generateSigma.R
@@ -188,6 +188,6 @@ generateSigma <- function(
            call. = FALSE)
     }
   } else {
-    Sigma
+    list(Sigma, path_matrix)
   }
 }

--- a/R/generatecSEMModel.r
+++ b/R/generatecSEMModel.r
@@ -173,7 +173,6 @@ generatecSEMModel <- function(
     if(!is.null(Phi_coefs)) {
       coef_df <- merge(coef_df, Phi_coefs, sort = FALSE)
     }
-
   } else if(!is.null(error_coefs)) {
     coef_df <- error_coefs
     if(!is.null(Phi_coefs)) {
@@ -191,10 +190,10 @@ generatecSEMModel <- function(
   ## Combine Structural, measurement/composite and error correlation matrices
   ## and add the rest of the information
   sme <-
-    unlist(lapply(sl, function(s) {
-      unlist(lapply(ml, function(m) {
-        unlist(lapply(el, function(e) {
-          lapply(Phil, function(Phi) {
+    unlist(lapply(Phil, function(Phi){
+      unlist(lapply(el, function(e) {
+        unlist(lapply(ml, function(m) {
+          lapply(sl, function(s){
             l <- list(
               "structural"  = xx$structural,
               "measurement" = xx$measurement,


### PR DESCRIPTION
The object ``model_list`` is created via the statement ``list("Models" = sme, "Coef_df" = coef_df)``. The problem is that the order of the two lists in this object are different, resulting in false combinations. 

The dataframe ``coef_df`` was being created via if-else-statements and the `merge(...)` function. The merging happend in the following order: path_coefs, measurement_coefs, error-coeffs and Phi-coeffs. 
This small example shows that the resulting dataframe will iterate over Phi values, then measurement, then error, then path coefficents: 
```
df_path <- data.frame(a = c(0, 1, 2, 3, 4, 5), b = c(0, 1, 2, 3, 4, 5))
df_measurement <- data.frame(e = c(0, 1, 2, 3, 4, 5), d = c(0, 1, 2, 3, 4, 5))
df_error <- data.frame(g = c(0, 1, 2, 3, 4, 5), f = c(0, 1, 2, 3, 4, 5))
df_phi <- data.frame(h = c(0, 1, 2, 3, 4, 5))

test_df <- merge(df_path, df_measurement, sort = FALSE)
test_df2 <- merge(test_df, df_error,  sort = FALSE)
test_df3 <- merge(test_df2, df_phi,  sort = FALSE)
```

On the other hand `lapply(...)` is being used to create the ``sme`` list containing all information for performing the data generating process. It will iterate through every value for path-coefficients then error, then measuremt then Phi, creating a different order than the object ``coef_df``. 

This will result that the combination in the ``list("Models" = sme, "Coef_df" = coef_df)`` object will be wrong. 

I changed the order of the `lapply(...)` chain such that now it will iteratre through every value for Phi, measurement error, then error coefficient and then path coefficients. This order now yields the same structure as the merge and if-else-statements. 

